### PR TITLE
Make SSL optional on websockets

### DIFF
--- a/Net.DDP.Client/DDPClient.cs
+++ b/Net.DDP.Client/DDPClient.cs
@@ -39,6 +39,11 @@ namespace Net.DDP.Client
             _connector.Connect(url);
         }
 
+        public void Connect(string url, bool useSSL)
+        {
+            _connector.Connect(url, useSSL);
+        }
+
         public void Call(string methodName, params string[] args)
         {
             string message = string.Format("\"msg\": \"method\",\"method\": \"{0}\",\"params\": [{1}],\"id\": \"{2}\"", methodName, CreateJSonArray(args), NextId());

--- a/Net.DDP.Client/DDPConnector.cs
+++ b/Net.DDP.Client/DDPConnector.cs
@@ -6,7 +6,7 @@ namespace Net.DDP.Client
     internal class DDPConnector
     {
         private WebSocket _socket;
-        private string _url=string.Empty;
+        private string _url = string.Empty;
         private int _isWait;
         private readonly IClient _client;
 
@@ -15,9 +15,9 @@ namespace Net.DDP.Client
             this._client = client;
         }
 
-        public void Connect(string url)
+        public void Connect(string url, bool useSSL = true)
         {
-            _url = "wss://" + url + "/websocket";
+            _url = string.Format("{0}://{1}/websocket", useSSL ? "wss" : "ws", url);
             _socket = new WebSocket(_url);
             _socket.MessageReceived += socket_MessageReceived;
             _socket.Opened += _socket_Opened;

--- a/Net.DDP.Client/IClient.cs
+++ b/Net.DDP.Client/IClient.cs
@@ -4,6 +4,7 @@
     {
         void AddItem(string jsonItem);
         void Connect(string url);
+        void Connect(string url, bool useSSL);
         void Call(string methodName, params string[] args);
         int Subscribe(string methodName, params string[] args);
         int GetCurrentRequestId();


### PR DESCRIPTION
At present SSL is enforced. This is good practice for deployment but during development is not necessarily an option. This provides an overload for Connect to not use SSL for websockets (ws:// rather than wss://)
