### PR TITLE
Allow calling methods which take objects as parameters

### DIFF
--- a/Net.DDP.Client/DDPClient.cs
+++ b/Net.DDP.Client/DDPClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Net.DDP.Client
 {
@@ -39,10 +39,10 @@ namespace Net.DDP.Client
             _connector.Connect(url);
         }
 
-        public void Call(string methodName, params string[] args)
+        public void Call(string methodName, params object[] args)
         {
-            string message = string.Format("\"msg\": \"method\",\"method\": \"{0}\",\"params\": [{1}],\"id\": \"{2}\"", methodName, CreateJSonArray(args), NextId());
-            message = "{" + message+ "}";
+            string message = string.Format("\"msg\": \"method\",\"method\": \"{0}\",\"params\": {1},\"id\": \"{2}\"", methodName, CreateJSonArray(args), NextId());
+            message = "{" + message + "}";
             _connector.Send(message);
         }
 
@@ -54,21 +54,12 @@ namespace Net.DDP.Client
             return GetCurrentRequestId();
         }
 
-        private string CreateJSonArray(params string[] args)
+        private string CreateJSonArray(params object[] args)
         {
             if (args == null)
-                return string.Empty;
+                return "[]";
 
-            StringBuilder argumentBuilder = new StringBuilder();
-            string delimiter=string.Empty;
-            for (int i = 0; i < args.Length; i++)
-            {
-                argumentBuilder.Append(delimiter);
-                argumentBuilder.AppendFormat("\"{0}\"", args[i]);
-                delimiter = ",";
-            }
-            
-            return argumentBuilder.ToString();
+            return JsonConvert.SerializeObject(args);
         }
         private int NextId()
         {

--- a/Net.DDP.Client/IClient.cs
+++ b/Net.DDP.Client/IClient.cs
@@ -4,7 +4,7 @@
     {
         void AddItem(string jsonItem);
         void Connect(string url);
-        void Call(string methodName, params string[] args);
+        void Call(string methodName, params object[] args);
         int Subscribe(string methodName, params string[] args);
         int GetCurrentRequestId();
     }


### PR DESCRIPTION
When calling a method, it is assumed that the parameters are all simple types that can be serialized as an array of strings.

This is not necessarily true. For example, when calling 'login' an object with user and password can be provided.

This change permits calls such as the following, whilst continuing to allow calling methods with simple types.

```
    client.Call("login", new {
        user = new {
            username = "myusername"
        },
        password = new {
            digest = "89e01536ac207279409d4de1e5253e01f4a1769e696db0d6062ca9b8f56767c8",
            algorithm = "sha-256"
        }
    });
```
