### PR TITLE
Throw an exception if the socket connection fails

### DIFF
--- a/Net.DDP.Client/DDPConnector.cs
+++ b/Net.DDP.Client/DDPConnector.cs
@@ -24,6 +24,10 @@ namespace Net.DDP.Client
             _socket.Open();
             _isWait = 1;
             this.Wait();
+            if (_socket.State != WebSocketState.Open)
+            {
+                throw new SocketException();
+            }
         }
 
         public void Close()
@@ -49,7 +53,7 @@ namespace Net.DDP.Client
 
         private void Wait()
         {
-            while (_isWait != 0)
+            while (_isWait != 0 && _socket.State == WebSocketState.Connecting)
             {
                 System.Threading.Thread.Sleep(100);
             }

--- a/Net.DDP.Client/DDPConnector.cs
+++ b/Net.DDP.Client/DDPConnector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using WebSocket4Net;
+using System.Net.Sockets;
 
 namespace Net.DDP.Client
 {


### PR DESCRIPTION
If the meteor sever is not running, then connect sits in an infinite loop, with the connection state of the WebSocket as 'Closed'.

Even if the server starts up later, because the socket is closed, it will not connect.

This patch checks that the underlying socket is still attempting to connect in the wait loop, and if not, bails with a SocketException.
