### PR TITLE
Update WebSocket4Net dependency

### DIFF
--- a/Net.DDP.Client/Net.DDP.Client.csproj
+++ b/Net.DDP.Client/Net.DDP.Client.csproj
@@ -42,9 +42,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebSocket4Net, Version=0.8.0.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WebSocket4Net.0.8\lib\net40\WebSocket4Net.dll</HintPath>
+    <Reference Include="WebSocket4Net, Version=0.12.0.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocket4Net.0.13.1\lib\net40\WebSocket4Net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Net.DDP.Client/packages.config
+++ b/Net.DDP.Client/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net40" />
-  <package id="WebSocket4Net" version="0.8" targetFramework="net40" />
+  <package id="WebSocket4Net" version="0.13.1" targetFramework="net40" />
 </packages>

--- a/NuGet.DDPClient/Package.nuspec
+++ b/NuGet.DDPClient/Package.nuspec
@@ -23,7 +23,7 @@
     <dependencies>
         <group targetFramework="net40">
           <dependency id="Newtonsoft.Json" version="6.0.1" />
-          <dependency id="WebSocket4Net" version="0.8.0" />
+          <dependency id="WebSocket4Net" version="0.13.1" />
         </group>
     </dependencies>
     <references></references>


### PR DESCRIPTION
Since version 0.8 there have been quite a few bug fixes and improved error handling in the WebSocket4Net library.

This brings it up to the latest version on nuget.

Unfortunately the newer version cannot be dropped in with a binding redirect due to a constructor change in version 0.11, so a re-compile of the library against the new version is required. A separate bug has been filed with WebSocket4Net on this.
